### PR TITLE
Patch log4j version to 2.17.1 to pick up CVE-2021-44832 fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 BrowserMob Proxy allows you to manipulate HTTP requests and responses, capture HTTP content, and export performance data as a [HAR file](http://www.softwareishard.com/blog/har-12-spec/).
 BMP works well as a standalone proxy server, but it is especially useful when embedded in Selenium tests.
 
-The latest version of BrowserMob Proxy is 2.1.5, powered by [LittleProxy](https://github.com/adamfisk/LittleProxy).
+The latest version of BrowserMob Proxy is 2.1.6, powered by [LittleProxy](https://github.com/adamfisk/LittleProxy).
 
 If you're running BrowserMob Proxy within a Java application or Selenium test, get started with [Embedded Mode](#getting-started-embedded-mode). If you want to run BMP from the
 command line as a standalone proxy, start with [Standalone](#getting-started-standalone).
@@ -14,7 +14,7 @@ To use BrowserMob Proxy in your tests or application, add the `browsermob-core` 
     <dependency>
         <groupId>net.lightbody.bmp</groupId>
         <artifactId>browsermob-core</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <scope>test</scope>
     </dependency>
 ```
@@ -74,7 +74,7 @@ The legacy interface, implicitly defined by the ProxyServer class, has been extr
     proxyServer.start();
     // [...]
 
-    // To use the LittleProxy-powered 2.1.5 release, simply change to
+    // To use the LittleProxy-powered 2.1.6 release, simply change to
     // the LegacyProxyServer interface and the adapter for the new
     // LittleProxy-based implementation:
     LegacyProxyServer proxyServer = new BrowserMobProxyServerLegacyAdapter();
@@ -205,7 +205,7 @@ If you're using Java and Selenium, the easiest way to get started is to embed th
     <dependency>
         <groupId>net.lightbody.bmp</groupId>
         <artifactId>browsermob-core</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <scope>test</scope>
     </dependency>
 ```
@@ -388,7 +388,7 @@ You'll need maven (`brew install maven` if you're on OS X):
 
     [~]$ mvn -DskipTests
 
-You'll find the standalone BrowserMob Proxy distributable zip at `browsermob-dist/target/browsermob-proxy-2.1.5-SNAPSHOT-bin.zip`. Unzip the contents and run the `browsermob-proxy` or `browsermob-proxy.bat` files in the `bin` directory.
+You'll find the standalone BrowserMob Proxy distributable zip at `browsermob-dist/target/browsermob-proxy-2.1.6-SNAPSHOT-bin.zip`. Unzip the contents and run the `browsermob-proxy` or `browsermob-proxy.bat` files in the `bin` directory.
 
 When you build the latest code from source, you'll have access to the latest snapshot release. To use the SNAPSHOT version in your code, modify the version in your pom:
 ```xml

--- a/browsermob-core/pom.xml
+++ b/browsermob-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>browsermob-proxy</artifactId>
         <groupId>net.lightbody.bmp</groupId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/browsermob-dist/pom.xml
+++ b/browsermob-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>browsermob-proxy</artifactId>
         <groupId>net.lightbody.bmp</groupId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/browsermob-legacy/pom.xml
+++ b/browsermob-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>browsermob-proxy</artifactId>
         <groupId>net.lightbody.bmp</groupId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/browsermob-rest/pom.xml
+++ b/browsermob-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>browsermob-proxy</artifactId>
         <groupId>net.lightbody.bmp</groupId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mitm/pom.xml
+++ b/mitm/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>browsermob-proxy</artifactId>
         <groupId>net.lightbody.bmp</groupId>
-        <version>2.1.6-SNAPSHOT</version>
+        <version>2.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.lightbody.bmp</groupId>
     <artifactId>browsermob-proxy</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.6</version>
     <modules>
         <module>browsermob-core</module>
         <module>browsermob-legacy</module>
@@ -68,7 +68,7 @@
 
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
 
-        <log4j.version>2.9.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
 
         <groovy.version>2.4.12</groovy.version>
         <groovy-eclipse-batch.version>2.4.3-01</groovy-eclipse-batch.version>


### PR DESCRIPTION
[Apache Log4j Security Vulnerabilities](https://logging.apache.org/log4j/2.x/security.html)

* Publish tag `2.1.6`
* Update `log4j` dependency version to `2.17.1` to patch CVE-2021-44832